### PR TITLE
Use latest NDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
           ./gradlew assembleRelease &&
           jar tvf $( find . -name '*-release.aar' ) |
           grep '\.so$'
+        env:
+          NDK_VERSION: "25.0.8775105"
 
       - name: Retrieve tag name
         uses: actions/github-script@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+- 2022-08-19 - v0.4.3
+    - using release v0.4.3 of lightarti-rest
+    - updating to latest gradle libraries

--- a/artiwrapper/app/build.gradle
+++ b/artiwrapper/app/build.gradle
@@ -6,6 +6,8 @@ android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
 
+    ndkVersion System.getenv('NDK_VERSION')
+
     defaultConfig {
         applicationId "org.c4dt.myapplication"
         minSdkVersion 23

--- a/artiwrapper/build.gradle
+++ b/artiwrapper/build.gradle
@@ -18,6 +18,8 @@ android {
     compileSdkVersion 30
     buildToolsVersion "30.0.3"
 
+    ndkVersion System.getenv('NDK_VERSION')
+
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 30

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.9.0'
+        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'org.mozilla.rust-android-gradle:plugin:0.9.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 12 19:34:16 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The ubuntu 20.04 image removed NDK 21 which gradle depends on. So updating the gradle dependencies and using NDK 25 now.